### PR TITLE
Validation fix for PluginManager in newer LPX.

### DIFF
--- a/MultiMeter.jucer
+++ b/MultiMeter.jucer
@@ -2,7 +2,7 @@
 
 <JUCERPROJECT id="epc7FC" name="MultiMeter" projectType="audioplug" useAppConfig="0"
               addUsingNamespaceToJuceHeader="0" displaySplashScreen="1" jucerFormatVersion="1"
-              companyName="Yulania">
+              companyName="Yulania" version="1.0">
   <MAINGROUP id="aK0CnT" name="MultiMeter">
     <GROUP id="{3D408716-D058-AAD0-D1C6-03CA40C62C16}" name="Controls">
       <FILE id="LwRUOc" name="Buttons.h" compile="0" resource="0" file="Source/Controls/Buttons.h"/>

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -228,7 +228,6 @@ void MultiMeterAudioProcessorEditor::resized()
 
 void MultiMeterAudioProcessorEditor::timerCallback()
 {
-
     auto& audioProcessorFifo = audioProcessor.fifo;
 
     // If the audioProcessor.fifo has items available for reading
@@ -238,6 +237,8 @@ void MultiMeterAudioProcessorEditor::timerCallback()
         while (audioProcessorFifo.pull(buffer))
         {
         }
+        
+        gonioMeter.update(buffer);
     }
     
     // After finishing pulling all buffers out of the fifo in timerCallback,

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -179,10 +179,7 @@ void MultiMeterAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, j
     #endif
     
     // Push the current audio buffer to the FIFO for processing
-//    DBG("BEFORE pushing data to FIFO: " << (buffer.getNumSamples()));
     fifo.push(buffer);
-//    DBG("AFTER pushing data to FIFO: " << (buffer.getNumSamples()));
-
 
     // Update the left and right channel FIFOs with the current audio buffer
     leftChannelFifo.update(buffer);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -179,7 +179,10 @@ void MultiMeterAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, j
     #endif
     
     // Push the current audio buffer to the FIFO for processing
+//    DBG("BEFORE pushing data to FIFO: " << (buffer.getNumSamples()));
     fifo.push(buffer);
+//    DBG("AFTER pushing data to FIFO: " << (buffer.getNumSamples()));
+
 
     // Update the left and right channel FIFOs with the current audio buffer
     leftChannelFifo.update(buffer);
@@ -238,10 +241,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout MultiMeterAudioProcessor::cr
 {
     // Create and return the parameter layout for the audio processor
     juce::AudioProcessorValueTreeState::ParameterLayout layout;
-    layout.add(std::make_unique<juce::AudioParameterFloat>("Scale Knob",
-        "Scale Knob",
-        juce::NormalisableRange<float>(50.f, 200.f, 1.f, 0.1),
-        100.f));
+    // Fix for AU plugins: https://forum.juce.com/t/failing-assert-in-juce-audioprocessor/51926
+    layout.add(std::make_unique<juce::AudioParameterFloat>(ParameterID{"Scale Knob", 1},
+                                                           "Scale Knob", juce::NormalisableRange<float>(50.f, 200.f, 1.f, 0.1), 100.f));
 
     return layout;
 }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -46,10 +46,12 @@ struct Fifo
     // Pushes an element into the FIFO buffer
     bool push(const T& t)
     {
-        auto write = fifo.read(1);
-        if (write.blockSize1 > 0)
+        int start1, size1, start2, size2;
+        fifo.prepareToWrite(1, start1, size1, start2, size2); // Prepare to write one element
+        if (size1 > 0)
         {
-            buffers[write.startIndex1] = t;
+            buffers[start1] = t;
+            fifo.finishedWrite(size1); // Update the write position
             return true;
         }
         return false;
@@ -58,10 +60,12 @@ struct Fifo
     // Pulls an element from the FIFO buffer
     bool pull(T& t)
     {
-        auto read = fifo.write(1);
-        if (read.blockSize1 > 0)
+        int start1, size1, start2, size2;
+        fifo.prepareToRead(1, start1, size1, start2, size2); // Prepare to read one element
+        if (size1 > 0)
         {
-            t = buffers[read.startIndex1];
+            t = buffers[start1]; // Retrieve the data
+            fifo.finishedRead(size1); // Update the read position
             return true;
         }
         return false;


### PR DESCRIPTION
Hey, great plugin! Thanks :)

I cloned your repo and ran it in LPX 10.8.1 (newest) but it crashed in the validation:

1 Channel Test:
Render Test at 512 frames
JUCE Assertion failure in PluginProcessor.h:177
JUCE Assertion failure in juce_AudioSampleBuffer.h:255
validation result: crashed validation

So I went into debug mode it and found in validation, (at least in LPX newer versions), we need to check for a mono channel, otherwise just set it to stereo.

Also, I changed the order in the Channel Enum for visibility since channels are zero-based and we read left channel first.